### PR TITLE
Fix for windows year 1970

### DIFF
--- a/macrobond_data_api/com/_metadata_directory.py
+++ b/macrobond_data_api/com/_metadata_directory.py
@@ -1,5 +1,6 @@
+import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 try:
     from pywintypes import TimeType
@@ -22,6 +23,15 @@ class _MetadataType:
         super().__init__()
         self.can_have_multiple_values = info.CanHaveMultipleValues
         self.restriction = info.Restriction
+
+
+def _convert_datetime_as_astimezone_utc(dt: datetime) -> datetime:
+    year = dt.year
+    if year > 1970:
+        return datetime(year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond).astimezone(timezone.utc)
+    return datetime(
+        year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond, tzinfo=timezone.utc
+    ) + timedelta(seconds=time.timezone)
 
 
 class _MetadataTypeDirectory:
@@ -67,10 +77,7 @@ class _MetadataTypeDirectory:
 
         # fall back if no type_info
         if isinstance(obj[0], TimeType):
-            obj = [
-                datetime(x.year, x.month, x.day, x.hour, x.minute, x.second, x.microsecond).astimezone(timezone.utc)
-                for x in obj
-            ]
+            obj = [_convert_datetime_as_astimezone_utc(x) for x in obj]
             return obj[0] if len(obj) == 1 else obj
         return obj[0] if len(obj) == 1 else list(obj)
 
@@ -81,10 +88,7 @@ class _MetadataTypeDirectory:
                 dt = obj[0]
                 return datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
             if name in ("LastModifiedTimeStamp"):
-                dt = obj[0]
-                return datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond).astimezone(
-                    timezone.utc
-                )
+                return _convert_datetime_as_astimezone_utc(obj[0])
             obj = [
                 datetime(x.year, x.month, x.day, x.hour, x.minute, x.second, x.microsecond, timezone.utc) for x in obj
             ]
@@ -104,14 +108,8 @@ class _MetadataTypeDirectory:
                     return [datetime(x.year, x.month, x.day) for x in obj]
                 return datetime(obj[0].year, obj[0].month, obj[0].day)
             if type_info.can_have_multiple_values:
-                return [
-                    datetime(x.year, x.month, x.day, x.hour, x.minute, x.second, x.microsecond).astimezone(timezone.utc)
-                    for x in obj
-                ]
-            dt = obj[0]
-            return datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond).astimezone(
-                timezone.utc
-            )
+                return [_convert_datetime_as_astimezone_utc(x) for x in obj]
+            return _convert_datetime_as_astimezone_utc(obj[0])
         if type_info.can_have_multiple_values:
             return list(obj)
         return obj[0]

--- a/macrobond_data_api/com/_metadata_directory.py
+++ b/macrobond_data_api/com/_metadata_directory.py
@@ -26,12 +26,14 @@ class _MetadataType:
 
 
 def _convert_datetime_as_astimezone_utc(dt: datetime) -> datetime:
-    year = dt.year
-    if year > 1970:
-        return datetime(year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond).astimezone(timezone.utc)
+    if dt.year > 1970:
+        return datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond).astimezone(
+            timezone.utc
+        )
+    delta = time.altzone if time.daylight != 0 else time.timezone
     return datetime(
-        year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond, tzinfo=timezone.utc
-    ) + timedelta(seconds=time.timezone)
+        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond, tzinfo=timezone.utc
+    ) + timedelta(seconds=delta)
 
 
 class _MetadataTypeDirectory:

--- a/tests/comparison_tests/revision_methods/get_observation_history.py
+++ b/tests/comparison_tests/revision_methods/get_observation_history.py
@@ -6,7 +6,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from macrobond_data_api.web import WebApi
 from macrobond_data_api.com import ComApi
 
-test_data = ["ustrad4488", "usgdp", "uscpi"]
+test_data = ["ustrad4488", "usgdp", "uscpi", "uslama1060"]
 
 
 def strip_time(d: Optional[datetime]) -> Optional[datetime]:

--- a/tests/comparison_tests/revision_methods/get_revision_info.py
+++ b/tests/comparison_tests/revision_methods/get_revision_info.py
@@ -4,7 +4,7 @@ from pandas.testing import assert_frame_equal
 from macrobond_data_api.web import WebApi
 from macrobond_data_api.com import ComApi
 
-test_data = ["ustrad4488", "usgdp", "uscpi", "ct_au_e_ao_c_22_v", "wocaes0868"]
+test_data = ["ustrad4488", "usgdp", "uscpi", "ct_au_e_ao_c_22_v", "wocaes0868", "uslama1060"]
 
 
 @pytest.mark.parametrize("name", test_data)

--- a/tests/comparison_tests/revision_methods/get_vintage_series.py
+++ b/tests/comparison_tests/revision_methods/get_vintage_series.py
@@ -5,7 +5,7 @@ from pandas.testing import assert_series_equal, assert_frame_equal
 from macrobond_data_api.web import WebApi
 from macrobond_data_api.com import ComApi
 
-test_data = ["ustrad4488", "usgdp", "uscpi"]
+test_data = ["ustrad4488", "usgdp", "uscpi", "uslama1060"]
 
 
 @pytest.mark.parametrize("name", test_data)

--- a/tests/comparison_tests/series_methods/get_one_entity.py
+++ b/tests/comparison_tests/series_methods/get_one_entity.py
@@ -4,7 +4,7 @@ from pandas.testing import assert_series_equal
 from macrobond_data_api.web import WebApi
 from macrobond_data_api.com import ComApi
 
-test_data = ["ustrad4488", "usgdp", "uscpi", "ct_au_e_ao_c_22_v", "wocaes0868"]
+test_data = ["ustrad4488", "usgdp", "uscpi", "ct_au_e_ao_c_22_v", "wocaes0868", "uslama1060"]
 
 
 @pytest.mark.parametrize("name", test_data)


### PR DESCRIPTION
This is blockd by new com error for meta "FirstRevisionTimeStamp"

assert web_datetime == com_datetime, "key " + key
AssertionError: key FirstRevisionTimeStamp
assert datetime.datetime(1991, 12, 20, 13, 30, tzinfo=datetime.timezone.utc) == datetime.datetime(1991, 12, 20, 12, 30, tzinfo=datetime.timezone.utc)
